### PR TITLE
Add build step to GitHub actions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,39 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - "*v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Build for MacOS x64
+      run: env GOOS=darwin GOARCH=amd64 go build -v -o ./bin/lively-macos-x64 .
+
+    - name: Build for Linux x64
+      run: env GOOS=linux GOARCH=amd64 go build -v -o ./bin/lively-linux-x64 .
+
+    - name: Build for Windows x64
+      run: env GOOS=windows GOARCH=amd64 go build -v -o ./bin/lively-windows-x64 .
+
+    - name: Create Pre-release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/v0.')
+      with:
+        prerelease: true
+        files: ./bin/*
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      if: ${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+      with:
+        files: ./bin/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+bin


### PR DESCRIPTION
Creates GitHub action that will automatically generate a release and build the binaries associated with it when a tag is pushed.

A `v0.*.*` tag will generate a pre-release.
A `v1.*.*` tag will generate a full-release.

This can definitely be improved, for example, a tag ending in `-a` (e.g. `v1.0.1-a`) could be used to generate a pre-release.

First step in fixing #2. Follow ups would include building a dmg correctly for use in MacOS